### PR TITLE
Improve gate detection and stop actions

### DIFF
--- a/custom_components/motorline_mconnect/api.py
+++ b/custom_components/motorline_mconnect/api.py
@@ -458,9 +458,16 @@ class MConnectClient:
                 for v in values or []
             )
 
+            # Check if this is a gate/door (may not support position or stop)
             is_gate = (
                 ("gate" in icon)
                 or ("door" in icon)
+            )
+
+            # Check if device has only_open_close attribute (doesn't support stop)
+            has_only_open_close = any(
+                v.get("attributes", {}).get("only_open_close") is True
+                for v in values or []
             )
 
             is_cover = (
@@ -506,6 +513,7 @@ class MConnectClient:
                     command_value_id=oc_id,
                     travel_time_s=tt,
                     supports_position=not is_gate,  # Gates don't support positions
+                    supports_stop=not has_only_open_close,  # Devices with only_open_close don't support stop
                 )
                 covers.append(cover)
                 continue

--- a/custom_components/motorline_mconnect/api.py
+++ b/custom_components/motorline_mconnect/api.py
@@ -452,10 +452,23 @@ class MConnectClient:
             )
 
             # --- classify device type ---
+            # Check if device has OpenClose values (covers/gates/shutters)
+            has_openclose_values = any(
+                "OpenClose" in (v.get("type") or "")
+                for v in values or []
+            )
+
+            is_gate = (
+                ("gate" in icon)
+                or ("door" in icon)
+            )
+
             is_cover = (
                 ("devices.types.shutter" in dev_type)
                 or ("shutter" in icon)
                 or ("blind" in icon)
+                or is_gate
+                or has_openclose_values
             )
             # Some lights arrive as SWITCH type but have a bulb/lamp icon
             is_light = (
@@ -492,7 +505,7 @@ class MConnectClient:
                     position=pos,
                     command_value_id=oc_id,
                     travel_time_s=tt,
-                    supports_position=True,
+                    supports_position=not is_gate,  # Gates don't support positions
                 )
                 covers.append(cover)
                 continue

--- a/custom_components/motorline_mconnect/cover.py
+++ b/custom_components/motorline_mconnect/cover.py
@@ -24,8 +24,10 @@ class MConnectCover(MConnectEntity, CoverEntity):
         feats = (
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
-            | CoverEntityFeature.STOP
         )
+        # Add STOP only if the device supports it
+        if getattr(obj, "supports_stop", True):
+            feats |= CoverEntityFeature.STOP
         # Add SET_POSITION only if the device supports it (not for gates)
         if getattr(obj, "supports_position", True):
             feats |= CoverEntityFeature.SET_POSITION
@@ -102,6 +104,10 @@ class MConnectCover(MConnectEntity, CoverEntity):
         )
 
     async def async_stop_cover(self, **kwargs) -> None:
+        # Only allow stop if the device supports it
+        if not getattr(self._obj, "supports_stop", True):
+            return
+
         vid = self._obj.command_value_id
         if not vid:
             return

--- a/custom_components/motorline_mconnect/cover.py
+++ b/custom_components/motorline_mconnect/cover.py
@@ -112,14 +112,8 @@ class MConnectCover(MConnectEntity, CoverEntity):
         if not vid:
             return
 
-        if not getattr(self._obj, "supports_position", True):
-            # For gates: send inverse position to stop movement
-            # If gate was opening (target=100), send close (0) to stop
-            # If gate was closing (target=0), send open (100) to stop
-            stop_position = 0 if self._last_target == 100 else 100
-        else:
-            # For blinds/shutters: send same position (original behavior)
-            stop_position = self._last_target if self._last_target is not None else 0
+        # Send the same position that was last targeted to stop movement
+        stop_position = self._last_target if self._last_target is not None else 0
 
         await self.coordinator.async_execute_with_retry(
             self.client.async_command,
@@ -128,7 +122,7 @@ class MConnectCover(MConnectEntity, CoverEntity):
             value_id=vid,
             position=stop_position,
         )
-        # Make the UI snap to the stopped percent
+        # Refresh to get updated position/status
         await self.coordinator.async_refresh()
         self._schedule_poke_refresh((0.5, 1.0, 2.0))
 

--- a/custom_components/motorline_mconnect/entity.py
+++ b/custom_components/motorline_mconnect/entity.py
@@ -15,7 +15,11 @@ class MConnectEntity(CoordinatorEntity):
         self._kind = kind
         self._obj = obj
         self._attr_unique_id = obj.id
-        self._attr_name = f"{obj.device.room_name} {obj.name}"
+        room_name = obj.device.room_name
+        if room_name:
+            self._attr_name = f"{room_name} {obj.name}"
+        else:
+            self._attr_name = obj.name
         # self._attr_name = f"{obj.name}"
         self._attr_has_entity_name = False
 

--- a/custom_components/motorline_mconnect/models.py
+++ b/custom_components/motorline_mconnect/models.py
@@ -43,5 +43,6 @@ class CoverDevice(BaseDeviceEntity):
     # No percentage in your dump, so position is None
     position: int | None = None
     command_value_id: str | None = None
-    travel_time_s: int | None = None  # <— add
-    supports_position: bool = True  # always true for MConnect shutters
+    travel_time_s: int | None = None
+    supports_position: bool = True  # Gates don't support positions
+    supports_stop: bool = True  # Some gates don't support stop


### PR DESCRIPTION
This PR improves the gate devices by:

- Better detection of gates and covers using device capabilities
- Gates now show only Open/Close/Stop controls (no position slider since they don't support intermediate positions)
- Fixed stop functionality for gates 
- Clean entity names when devices aren't assigned to rooms

Tested on my Motorline Galo 500 (MC91BL-SC V0.Rev110) with the MConnect Link wifi addon (v0.1.3 - 25.10.021030)